### PR TITLE
Adding ` _ = self.state` in Reactor initializer

### DIFF
--- a/CodeSnippets/ReactorKit - Reactor.codesnippet
+++ b/CodeSnippets/ReactorKit - Reactor.codesnippet
@@ -25,6 +25,7 @@ final class &lt;#Name#&gt;: Reactor {
   let initialState: State
 
   init() {
+    defer { _ = self.state }
     self.initialState = State()
   }
 


### PR DESCRIPTION
I remember you recommended to add `_ = self.state` in Reactor initializer. 

How about adding this part to the snippet?